### PR TITLE
Reduce presentation lag.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,7 @@ name = "emergent-ui"
 version = "0.1.0"
 dependencies = [
  "emergent-drawing 0.1.0",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "winit 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/lib/ui_tests.rs
+++ b/src/lib/ui_tests.rs
@@ -95,7 +95,7 @@ mod tests {
 
         let mut stacked = Drawing::BackToFront(simple_layout::stacked(vec![d1, d2], &measure, v));
         let stacked_bounds: Rect = (*stacked.fast_bounds(&measure).as_bounds().unwrap()).into();
-        dbg!(&stacked_bounds);
+        debug!("{:?}", stacked_bounds);
         stacked.draw(stacked_bounds, stroke_paint_green);
         stacked.render()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,8 @@ fn main() {
             let frame_layout = render_surface.window().frame_layout();
             trace!("window frame layout: {:?}", frame_layout);
             if frame.layout == frame_layout {
-                let _future = context.render(future, frame_state, drawing_backend, &frame);
+                previous_frame_end =
+                    context.render(previous_frame_end, frame_state, drawing_backend, &frame);
             } else {
                 warn!(
                     "skipping frame, wrong layout, expected {:?}, window: {:?}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use emergent_config::WindowPlacement;
 use emergent_drawing::{font, functions, Font, MeasureText};
 use emergent_presenter::Support;
 use emergent_ui as ui;
-use emergent_ui::{Window, DPI};
+use emergent_ui::{measure_fn, Window, DPI};
 use skia_safe::{icu, Typeface};
 use std::{env, path, thread};
 use tears::{Application, ThreadSpawnExecutor};
@@ -106,11 +106,14 @@ fn main() {
             renderer::create_context_and_frame_state(instance, render_surface.clone());
         let frame_state = &mut frame_state;
         let drawing_backend = &mut context.new_skia_backend().unwrap();
-        let mut future: Box<dyn GpuFuture> = Box::new(sync::now(context.device.clone()));
+        let mut previous_frame_end: Box<dyn GpuFuture> =
+            Box::new(sync::now(context.device.clone()));
 
         while !application.model().close_requested() {
             let frame_layout = render_surface.window().frame_layout();
-            let presentation = application.model_mut().render_presentation(&frame_layout);
+            let presentation = measure_fn("render_presentation", || {
+                application.model_mut().render_presentation(&frame_layout)
+            });
             let frame = Frame::new(frame_layout, presentation);
 
             // even if we drop the frame, we want to recreate the swapchain so that we are
@@ -130,12 +133,7 @@ fn main() {
                 );
             }
 
-            // if we don't drop the future here, the last image rendered won't be shown.
-            // TODO: Can't we do this asynchronously, or run the
-            //       application update asynchronously here?
-            future = Box::new(sync::now(context.device.clone()));
-
-            application.update();
+            measure_fn("application.update()", || application.update());
         }
 
         debug!("shutting down renderer loop");
@@ -179,6 +177,12 @@ fn main() {
                     }
                 }
             },
+            // swallow events that would clog the trace log.
+            Event::DeviceEvent { .. }
+            | Event::NewEvents(_)
+            | Event::MainEventsCleared
+            | Event::RedrawEventsCleared => {}
+
             event => {
                 trace!("unhandled event: {:?}", event);
             }

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
 [dependencies]
+log = "0.4.8"
 emergent-drawing = { path = "../drawing" }
 serde = { version = "1.0.100", features = ["derive"] }
 winit = { version = "0.20.0", features = ["serde"] }

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -1,5 +1,11 @@
+#[macro_use]
+extern crate log;
+
 mod frame_layout;
 pub use frame_layout::*;
+
+mod measure;
+pub use measure::*;
 
 mod window;
 pub use window::*;

--- a/ui/src/measure.rs
+++ b/ui/src/measure.rs
@@ -1,0 +1,12 @@
+use std::time::Instant;
+
+pub fn measure_fn<R>(ctx: &str, f: impl FnOnce() -> R) -> R {
+    let start = Instant::now();
+    let r = f();
+    trace!(
+        "measured {}: {:?}",
+        ctx,
+        Instant::now().saturating_duration_since(start)
+    );
+    r
+}

--- a/ui/src/window_msg.rs
+++ b/ui/src/window_msg.rs
@@ -2,6 +2,7 @@ use crate::{FrameLayout, Window};
 use emergent_drawing::Point;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+
 pub use winit::event::{
     // winit re-exports:
     AxisId,


### PR DESCRIPTION
This PR measures a number of rendering steps to the trace log and reduces the presentation lag by setting the presentation Vulkan mode to mailbox, immediate, fifo, relaxed, whichever is available first.