### PR TITLE
Add Gesture Recognizer Input Subscriptions

### DIFF
--- a/presentation/src/presentation.rs
+++ b/presentation/src/presentation.rs
@@ -1,8 +1,14 @@
-use crate::{Scope, Scoped};
+use crate::{Scope, ScopePath, Scoped};
 use emergent_drawing::{
     BackToFront, Clip, Clipped, DrawTo, Drawing, DrawingBounds, DrawingFastBounds, DrawingTarget,
     MeasureText, Outset, Paint, ReplaceWith, Transform, Transformed, Visualize, RGB,
 };
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct PresentationMarker;
+
+pub type PresentationScope = Scope<PresentationMarker>;
+pub type PresentationPath = ScopePath<PresentationMarker>;
 
 /// A presentation is a composable hierarchy of drawing commands and scoped areas.
 ///
@@ -12,7 +18,7 @@ pub enum Presentation {
     Empty,
     /// Defines a presentation scope.
     /// This qualifies all nested names with the scope's name.
-    Scoped(Scope<Presentation>, Box<Presentation>),
+    Scoped(PresentationScope, Box<Presentation>),
     /// Defines a named area around the (fast) bounds of a presentation, including an Outset.
     Area(Outset, Box<Presentation>),
     /// Defines an area by providing a Clip at the current drawing position and scope.
@@ -33,8 +39,8 @@ impl Default for Presentation {
     }
 }
 
-impl Scoped<Presentation> for Presentation {
-    fn scoped(self, scope: impl Into<Scope<Presentation>>) -> Self {
+impl Scoped<PresentationMarker> for Presentation {
+    fn scoped(self, scope: impl Into<PresentationScope>) -> Self {
         Self::Scoped(scope.into(), self.into())
     }
 }
@@ -110,7 +116,7 @@ impl Presentation {
         Presentation::Area(outset.into(), self.into())
     }
 
-    pub fn scoped(self, scope: impl Into<Scope<Presentation>>) -> Self {
+    pub fn scoped(self, scope: impl Into<PresentationScope>) -> Self {
         Presentation::Scoped(scope.into(), self.into())
     }
 

--- a/presenter/src/context.rs
+++ b/presenter/src/context.rs
@@ -15,7 +15,6 @@ use emergent_drawing::{Bounds, MeasureText, Text, Vector};
 use emergent_presentation::{Scope, ScopePath};
 use emergent_ui::FrameLayout;
 use std::any;
-use std::any::Any;
 use std::rc::Rc;
 
 // Can't use `Context` here for marking scopes, because it does not support certain trait which Scope / ScopePath needs

--- a/presenter/src/hit_test.rs
+++ b/presenter/src/hit_test.rs
@@ -1,10 +1,7 @@
 //! Single point presentation hit testing.
 
 use emergent_drawing::{Clip, Contains, DrawingFastBounds, MeasureText, Path, Point};
-use emergent_presentation::{Presentation, Scope, ScopePath};
-
-pub type PresentationScope = Scope<Presentation>;
-pub type PresentationPath = ScopePath<Presentation>;
+use emergent_presentation::{Presentation, PresentationPath, Scope, ScopePath};
 
 pub trait PathContainsPoint {
     fn path_contains_point(&self, path: &Path, p: Point) -> bool;

--- a/presenter/src/hit_test.rs
+++ b/presenter/src/hit_test.rs
@@ -1,7 +1,7 @@
 //! Single point presentation hit testing.
 
 use emergent_drawing::{Clip, Contains, DrawingFastBounds, MeasureText, Path, Point};
-use emergent_presentation::{Presentation, PresentationPath, Scope, ScopePath};
+use emergent_presentation::{Presentation, PresentationPath};
 
 pub trait PathContainsPoint {
     fn path_contains_point(&self, path: &Path, p: Point) -> bool;

--- a/presenter/src/host.rs
+++ b/presenter/src/host.rs
@@ -1,10 +1,10 @@
-use crate::recognizer::{Recognizer, Subscription, Subscriptions};
+use crate::recognizer::Recognizer;
 use crate::{
     AreaHitTest, Context, GestureRecognizer, InputState, RecognizerRecord, ScopedStore, Support,
     View,
 };
 use emergent_presentation::Presentation;
-use emergent_ui::{ElementState, FrameLayout, WindowEvent, WindowMessage};
+use emergent_ui::{FrameLayout, WindowMessage};
 use std::any::TypeId;
 use std::collections::HashSet;
 use std::mem;
@@ -88,7 +88,7 @@ impl<Msg> Host<Msg> {
             .iter_mut()
             // filter_map because we need mutable access.
             .filter_map(|r| {
-                if wants_event(r.subscriptions(), &msg.event)
+                if r.subscriptions().wants_event(&msg.event)
                     || presentation_scope_hits.contains(r.presentation_path())
                 {
                     Some(r)
@@ -123,25 +123,4 @@ impl<Msg> Host<Msg> {
             .flatten()
             .collect()
     }
-}
-
-impl Subscription {
-    pub fn wants(&self, event: &WindowEvent) -> bool {
-        match self {
-            Subscription::ButtonContinuity(b) => match event {
-                WindowEvent::CursorMoved(_) => true,
-                WindowEvent::MouseInput { state, button }
-                    if *state == ElementState::Released && *button == *b =>
-                {
-                    true
-                }
-                _ => false,
-            },
-            Subscription::Ticks => false,
-        }
-    }
-}
-
-fn wants_event(subscriptions: &Subscriptions, event: &WindowEvent) -> bool {
-    subscriptions.iter().any(|s| s.wants(event))
 }

--- a/presenter/src/host.rs
+++ b/presenter/src/host.rs
@@ -1,4 +1,4 @@
-use crate::recognizer::Recognizer;
+use crate::recognizer::{AutoSubscribe, Recognizer};
 use crate::{
     AreaHitTest, Context, GestureRecognizer, InputState, RecognizerRecord, ScopedStore, Support,
     View,
@@ -110,6 +110,11 @@ impl<Msg> Host<Msg> {
                         .map(|s| s.deref().type_id())
                         .collect::<Vec<TypeId>>()
                 );
+
+                // process automatic subscriptions _before_ dispatching the message into the recognizer, so that it
+                // can veto.
+
+                msg.event.auto_subscribe(recognizer.subscriptions());
 
                 let mut input_state =
                     InputState::new(c.clone(), recognizer.subscriptions().clone(), states);

--- a/presenter/src/input_state.rs
+++ b/presenter/src/input_state.rs
@@ -1,5 +1,4 @@
 use crate::recognizer;
-use crate::recognizer::{Subscription, Subscriptions};
 use crate::ContextPath;
 use std::any;
 use std::any::{Any, TypeId};
@@ -31,7 +30,7 @@ impl InputState {
         }
     }
 
-    pub fn into_states(self) -> (Subscriptions, Vec<Box<dyn Any>>) {
+    pub fn into_states(self) -> (recognizer::Subscriptions, Vec<Box<dyn Any>>) {
         (self.subscriptions, self.states)
     }
 
@@ -39,16 +38,16 @@ impl InputState {
     // subscription
     //
 
-    pub fn subscribe(&mut self, subscription: Subscription) -> bool {
-        self.subscriptions.insert(subscription)
+    pub fn subscribe(&mut self, subscription: recognizer::Subscription) -> bool {
+        self.subscriptions.subscribe(subscription)
     }
 
-    pub fn unsubscribe(&mut self, subscription: Subscription) -> bool {
-        self.subscriptions.remove(&subscription)
+    pub fn unsubscribe(&mut self, subscription: &recognizer::Subscription) -> bool {
+        self.subscriptions.unsubscribe(&subscription)
     }
 
-    pub fn is_subscribed(&self, subscription: Subscription) -> bool {
-        self.subscriptions.contains(&subscription)
+    pub fn is_subscribed(&self, subscription: &recognizer::Subscription) -> bool {
+        self.subscriptions.is_subscribed(subscription)
     }
 
     //

--- a/presenter/src/input_state.rs
+++ b/presenter/src/input_state.rs
@@ -1,12 +1,17 @@
+use crate::recognizer;
+use crate::recognizer::{Subscription, Subscriptions};
 use crate::ContextPath;
 use std::any;
 use std::any::{Any, TypeId};
 use std::ops::Deref;
 
-/// Represents all the state that is modified while input is being processed.
+/// The `InputState` maintains all the state that may be accessed and modified while input is being processed by one
+/// single gesture recognizer.
 pub struct InputState {
-    /// The recognizer's path. This is used for resolving states.
+    /// The recognizer's context. This is used for resolving states.
     recognizer_context: ContextPath,
+    /// The subscriptions of the recognizer.
+    subscriptions: recognizer::Subscriptions,
     /// The states available to be modified by the gesture recognizer.
     /// There should be a very limited amount of states per context path, so a vector is fine for doing
     /// lookups.
@@ -16,17 +21,39 @@ pub struct InputState {
 impl InputState {
     pub fn new(
         recognizer_context: ContextPath,
+        subscriptions: recognizer::Subscriptions,
         states: impl IntoIterator<Item = Box<dyn Any>>,
     ) -> Self {
         Self {
             recognizer_context,
+            subscriptions,
             states: states.into_iter().collect(),
         }
     }
 
-    pub fn into_states(self) -> Vec<Box<dyn Any>> {
-        self.states
+    pub fn into_states(self) -> (Subscriptions, Vec<Box<dyn Any>>) {
+        (self.subscriptions, self.states)
     }
+
+    //
+    // subscription
+    //
+
+    pub fn subscribe(&mut self, subscription: Subscription) -> bool {
+        self.subscriptions.insert(subscription)
+    }
+
+    pub fn unsubscribe(&mut self, subscription: Subscription) -> bool {
+        self.subscriptions.remove(&subscription)
+    }
+
+    pub fn is_subscribed(&self, subscription: Subscription) -> bool {
+        self.subscriptions.contains(&subscription)
+    }
+
+    //
+    // context associated state
+    //
 
     /// Modify a typed state record.
     pub fn modify<S: 'static>(&mut self, f: impl FnOnce(&mut S)) {

--- a/presenter/src/lib.rs
+++ b/presenter/src/lib.rs
@@ -22,7 +22,7 @@ pub use context::*;
 pub mod recognizer;
 
 mod recognizer_record;
-pub use recognizer_record::*;
+pub(crate) use recognizer_record::*;
 
 mod scoped_store;
 pub use scoped_store::*;

--- a/presenter/src/recognizer.rs
+++ b/presenter/src/recognizer.rs
@@ -1,27 +1,17 @@
 use crate::{GestureRecognizer, InputState};
-use emergent_ui::{MouseButton, WindowMessage};
+use emergent_ui::WindowMessage;
 pub use mover::MoverRecognizer;
-use std::collections::HashSet;
 
 pub mod pan;
 pub use pan::PanRecognizer;
+
+mod subscriptions;
+pub use subscriptions::*;
 
 pub mod tap;
 pub use tap::TapRecognizer;
 
 pub mod mover;
-
-pub type Subscriptions = HashSet<Subscription>;
-
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
-pub enum Subscription {
-    /// Subscribed to continuity events after a specific mouse button was pressed.
-    ///
-    /// These are automatically subscribed for every recognizer that receives button presses.
-    ButtonContinuity(MouseButton),
-    /// Subscribed to timer ticks once per frame.
-    Ticks,
-}
 
 // Below follows a rather convoluted way of transporting a gesture recognizer including its subscription
 // state through a `Box<Any>`.

--- a/presenter/src/recognizer.rs
+++ b/presenter/src/recognizer.rs
@@ -1,3 +1,8 @@
+use crate::{GestureRecognizer, InputState};
+use emergent_ui::{MouseButton, WindowMessage};
+pub use mover::MoverRecognizer;
+use std::collections::HashSet;
+
 pub mod pan;
 pub use pan::PanRecognizer;
 
@@ -5,4 +10,67 @@ pub mod tap;
 pub use tap::TapRecognizer;
 
 pub mod mover;
-pub use mover::MoverRecognizer;
+
+pub type Subscriptions = HashSet<Subscription>;
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub enum Subscription {
+    /// Subscribed to continuity events after a specific mouse button was pressed.
+    ///
+    /// These are automatically subscribed for every recognizer that receives button presses.
+    ButtonContinuity(MouseButton),
+    /// Subscribed to timer ticks once per frame.
+    Ticks,
+}
+
+// Below follows a rather convoluted way of transporting a gesture recognizer including its subscription
+// state through a `Box<Any>`.
+// TODO: find a simpler way.
+
+pub(crate) trait Recognizer<Event>: GestureRecognizer<Event = Event> {
+    fn subscriptions(&mut self) -> &mut Subscriptions;
+}
+
+pub(crate) struct RecognizerWithSubscription<R>
+where
+    R: GestureRecognizer,
+{
+    pub recognizer: R,
+    pub subscriptions: Subscriptions,
+}
+
+impl<R> From<R> for RecognizerWithSubscription<R>
+where
+    R: GestureRecognizer,
+{
+    fn from(r: R) -> Self {
+        Self {
+            recognizer: r,
+            subscriptions: Subscriptions::default(),
+        }
+    }
+}
+
+impl<R> Recognizer<R::Event> for RecognizerWithSubscription<R>
+where
+    R: GestureRecognizer,
+{
+    fn subscriptions(&mut self) -> &mut Subscriptions {
+        &mut self.subscriptions
+    }
+}
+
+impl<R> GestureRecognizer for RecognizerWithSubscription<R>
+where
+    R: GestureRecognizer,
+{
+    type Event = R::Event;
+
+    fn dispatch(
+        &mut self,
+        context: &mut InputState,
+        message: WindowMessage,
+    ) -> Option<Self::Event> {
+        self.recognizer.dispatch(context, message)
+    }
+}

--- a/presenter/src/recognizer/subscriptions.rs
+++ b/presenter/src/recognizer/subscriptions.rs
@@ -48,3 +48,22 @@ impl Subscription {
         }
     }
 }
+
+pub(crate) trait AutoSubscribe {
+    /// the set of subscriptions to add or to remove in response to an event.
+    fn auto_subscribe(&self, subscriptions: &mut Subscriptions);
+}
+
+impl AutoSubscribe for WindowEvent {
+    fn auto_subscribe(&self, subscriptions: &mut Subscriptions) {
+        match self {
+            WindowEvent::MouseInput { state, button } if *state == ElementState::Pressed => {
+                subscriptions.subscribe(Subscription::ButtonContinuity(*button));
+            }
+            WindowEvent::MouseInput { state, button } if *state == ElementState::Released => {
+                subscriptions.unsubscribe(&Subscription::ButtonContinuity(*button));
+            }
+            _ => {}
+        }
+    }
+}

--- a/presenter/src/recognizer/subscriptions.rs
+++ b/presenter/src/recognizer/subscriptions.rs
@@ -1,0 +1,50 @@
+use emergent_ui::{ElementState, MouseButton, WindowEvent};
+use std::collections::HashSet;
+
+#[derive(Clone, PartialEq, Eq, Default, Debug)]
+pub struct Subscriptions(HashSet<Subscription>);
+
+impl Subscriptions {
+    pub fn subscribe(&mut self, subscription: Subscription) -> bool {
+        self.0.insert(subscription)
+    }
+
+    pub fn unsubscribe(&mut self, subscription: &Subscription) -> bool {
+        self.0.remove(subscription)
+    }
+
+    pub fn is_subscribed(&self, subscription: &Subscription) -> bool {
+        self.0.contains(subscription)
+    }
+
+    pub fn wants_event(&self, event: &WindowEvent) -> bool {
+        self.0.iter().any(|s| s.wants_event(event))
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub enum Subscription {
+    /// Subscribed to continuity events after a specific mouse button was pressed.
+    ///
+    /// These are automatically subscribed for every recognizer that receives button presses.
+    ButtonContinuity(MouseButton),
+    /// Subscribed to timer ticks once per frame.
+    Ticks,
+}
+
+impl Subscription {
+    pub fn wants_event(&self, event: &WindowEvent) -> bool {
+        match self {
+            Subscription::ButtonContinuity(b) => match event {
+                WindowEvent::CursorMoved(_) => true,
+                WindowEvent::MouseInput { state, button }
+                    if *state == ElementState::Released && *button == *b =>
+                {
+                    true
+                }
+                _ => false,
+            },
+            Subscription::Ticks => false,
+        }
+    }
+}

--- a/presenter/src/recognizer_record.rs
+++ b/presenter/src/recognizer_record.rs
@@ -1,10 +1,8 @@
-use crate::recognizer::{Recognizer, RecognizerWithSubscription, Subscription};
+use crate::recognizer::{Recognizer, RecognizerWithSubscription, Subscriptions};
 use crate::{recognizer, ContextPath, ContextScope, GestureRecognizer, InputState, ScopedState};
 use emergent_presentation::{PresentationPath, PresentationScope, Scoped};
 use emergent_ui::WindowMessage;
 use std::any::Any;
-use std::collections::hash_map::RandomState;
-use std::collections::HashSet;
 
 type RecognizerResolver<Event> =
     Box<dyn Fn(&mut Box<dyn Any>) -> &mut dyn recognizer::Recognizer<Event>>;
@@ -84,7 +82,7 @@ impl<Event> GestureRecognizer for RecognizerRecord<Event> {
 }
 
 impl<Event> Recognizer<Event> for RecognizerRecord<Event> {
-    fn subscriptions(&mut self) -> &mut HashSet<Subscription, RandomState> {
+    fn subscriptions(&mut self) -> &mut Subscriptions {
         let recognizer = &mut self.recognizer;
         let resolver = &self.resolver;
 

--- a/presenter/src/recognizer_record.rs
+++ b/presenter/src/recognizer_record.rs
@@ -1,9 +1,6 @@
 use crate::recognizer::{Recognizer, RecognizerWithSubscription, Subscription};
-use crate::{
-    recognizer, ContextPath, ContextScope, GestureRecognizer, InputState, PresentationPath,
-    PresentationScope, ScopedState,
-};
-use emergent_presentation::Scoped;
+use crate::{recognizer, ContextPath, ContextScope, GestureRecognizer, InputState, ScopedState};
+use emergent_presentation::{PresentationPath, PresentationScope, Scoped};
 use emergent_ui::WindowMessage;
 use std::any::Any;
 use std::collections::hash_map::RandomState;

--- a/presenter/src/view.rs
+++ b/presenter/src/view.rs
@@ -1,8 +1,8 @@
-use crate::{Context, ContextPath, ContextScope, PresentationScope, RecognizerRecord, ScopedState};
+use crate::{Context, ContextPath, ContextScope, RecognizerRecord, ScopedState};
 use emergent_drawing::{
     Drawing, DrawingBounds, DrawingFastBounds, MeasureText, ReplaceWith, Transform, Transformed,
 };
-use emergent_presentation::{Presentation, Scoped};
+use emergent_presentation::{Presentation, PresentationScope, Scoped};
 use std::any::Any;
 use std::cell::RefCell;
 

--- a/presenter/src/view.rs
+++ b/presenter/src/view.rs
@@ -79,7 +79,9 @@ impl<Msg> View<Msg> {
         &self.presentation
     }
 
-    pub fn destructure(self) -> (Presentation, Vec<RecognizerRecord<Msg>>, Vec<ScopedState>) {
+    pub(crate) fn destructure(
+        self,
+    ) -> (Presentation, Vec<RecognizerRecord<Msg>>, Vec<ScopedState>) {
         (self.presentation, self.recognizers, self.states)
     }
 

--- a/src/lib/window_application.rs
+++ b/src/lib/window_application.rs
@@ -26,7 +26,7 @@
 
 use emergent_drawing::Point;
 use emergent_presentation::Presentation;
-use emergent_presenter::{AreaHitTest, Host, Support, ViewRenderer};
+use emergent_presenter::{Host, Support, ViewRenderer};
 use emergent_ui::{FrameLayout, ModifiersState, WindowEvent, WindowMessage, WindowState, DPI};
 use std::cell::RefCell;
 use tears::{Cmd, Model};

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,7 @@ fn main() {
                 WindowEvent::Resized(_) => {
                     let event =
                         ui::WindowEvent::from_winit(window_surface.window(), event).unwrap();
-                    mailbox.post(WindowApplicationMsg::Window(event));
+                    mailbox.post(WindowApplicationMsg::WindowEvent(event));
                     // TODO: handle window placement changes in a unified way
                     // (isn't this the application's job?)
                     if window_placement.update(window_surface.window()) {
@@ -157,7 +157,7 @@ fn main() {
                 WindowEvent::Moved(_) => {
                     let event =
                         ui::WindowEvent::from_winit(window_surface.window(), event).unwrap();
-                    mailbox.post(WindowApplicationMsg::Window(event));
+                    mailbox.post(WindowApplicationMsg::WindowEvent(event));
                     if window_placement.update(window_surface.window()) {
                         window_placement.store()
                     }
@@ -166,7 +166,7 @@ fn main() {
                     // also forward this to the application, which is expected to shut down in response.
                     let event =
                         ui::WindowEvent::from_winit(window_surface.window(), event).unwrap();
-                    mailbox.post(WindowApplicationMsg::Window(event));
+                    mailbox.post(WindowApplicationMsg::WindowEvent(event));
 
                     info!("close requested");
                     *control_flow = ControlFlow::Exit
@@ -174,7 +174,7 @@ fn main() {
                 event => {
                     if let Some(event) = ui::WindowEvent::from_winit(window_surface.window(), event)
                     {
-                        mailbox.post(WindowApplicationMsg::Window(event));
+                        mailbox.post(WindowApplicationMsg::WindowEvent(event));
                     }
                 }
             },


### PR DESCRIPTION
Gesture recognizers need to be able to subscribe to input events and store these subscriptions alongside their state.