### PR TITLE
Show errors first

### DIFF
--- a/presenter/src/component.rs
+++ b/presenter/src/component.rs
@@ -1,1 +1,0 @@
-pub mod list;

--- a/presenter/src/lib.rs
+++ b/presenter/src/lib.rs
@@ -4,8 +4,8 @@ extern crate log;
 mod hit_test;
 pub use hit_test::*;
 
-mod declarative;
-pub use declarative::*;
+mod data;
+pub use data::*;
 
 mod host;
 pub use host::*;

--- a/src/lib/compiler_message.rs
+++ b/src/lib/compiler_message.rs
@@ -1,8 +1,10 @@
 //! Rendering of compiler messages.
 
+use cargo_metadata::diagnostic::DiagnosticLevel;
 use cargo_metadata::CompilerMessage;
 use emergent_drawing::{font, functions::*, Drawing, DrawingTarget, Font, Paint, RGB};
 use emergent_terminal::{color_schemes, term, text_attributor};
+use std::cmp::Ordering;
 
 pub trait ToDrawing {
     fn to_drawing(&self) -> Drawing;
@@ -86,6 +88,25 @@ impl ToDrawing for CompilerMessage {
                 drawing
             }
         }
+    }
+}
+
+/// Orders by diagnostic level, from the most severe level to the least.
+pub fn diagnostic_level_ordering(l: &CompilerMessage, r: &CompilerMessage) -> Ordering {
+    diagnostic_level_severity(l)
+        .cmp(&diagnostic_level_severity(r))
+        .reverse()
+}f
+
+/// Returns the diagnostic level as an usize, A higher usize means a diagnostic level of an higher severity.
+fn diagnostic_level_severity(compiler_message: &CompilerMessage) -> usize {
+    match compiler_message.message.level {
+        DiagnosticLevel::Ice => 5,
+        DiagnosticLevel::Error => 4,
+        DiagnosticLevel::Warning => 3,
+        DiagnosticLevel::Note => 2,
+        DiagnosticLevel::Help => 1,
+        DiagnosticLevel::Unknown => 0,
     }
 }
 

--- a/src/lib/compiler_message.rs
+++ b/src/lib/compiler_message.rs
@@ -96,7 +96,7 @@ pub fn diagnostic_level_ordering(l: &CompilerMessage, r: &CompilerMessage) -> Or
     diagnostic_level_severity(l)
         .cmp(&diagnostic_level_severity(r))
         .reverse()
-}f
+}
 
 /// Returns the diagnostic level as an usize, A higher usize means a diagnostic level of an higher severity.
 fn diagnostic_level_severity(compiler_message: &CompilerMessage) -> usize {

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -3,26 +3,19 @@
 #[macro_use]
 extern crate log;
 
+pub use capture::*;
+pub use frame::*;
+pub use line_breaking::*;
+pub use msg::*;
 use std::thread::JoinHandle;
 
 mod capture;
-pub use capture::*;
-
-mod frame;
-pub use frame::*;
-
 pub mod compiler_message;
-
+mod frame;
 pub mod libtest;
-
 mod line_breaking;
-pub use line_breaking::*;
-
 mod move_predictor;
-
 mod msg;
-pub use msg::*;
-
 mod test_capture;
 pub mod test_runner;
 pub mod test_watcher;


### PR DESCRIPTION
The list of compiler messages must be ordered by severity with Ices and errors at the top.
