### PR TITLE
Introduce ViewBuilder<Msg> and ScopedView<Msg>

### DIFF
--- a/presenter/src/host.rs
+++ b/presenter/src/host.rs
@@ -1,6 +1,7 @@
 use crate::input_processor::{Subscriber, Subscription};
 use crate::{
     AreaHitTest, Context, InputProcessor, InputState, ProcessorRecord, ScopedStore, Support, View,
+    ViewBuilder,
 };
 use emergent_presentation::Presentation;
 use emergent_ui::{FrameLayout, WindowMessage};
@@ -32,8 +33,11 @@ impl<Msg> Host<Msg> {
         }
     }
 
-    pub fn present(&mut self, boundary: FrameLayout, present: impl FnOnce(Context) -> View<Msg>)
-    where
+    pub fn present(
+        &mut self,
+        boundary: FrameLayout,
+        present: impl FnOnce(ViewBuilder<Msg>) -> View<Msg>,
+    ) where
         Msg: 'static,
     {
         // get all the states from the previous run.
@@ -44,7 +48,8 @@ impl<Msg> Host<Msg> {
         let store = store.merged(processor_store);
 
         let context = Context::new(self.support.clone(), boundary, store);
-        let (presentation, processors, states) = present(context).destructure();
+        let builder = ViewBuilder::new(context);
+        let (presentation, processors, states) = present(builder).destructure();
 
         self.presentation = presentation;
         self.processors = processors;

--- a/presenter/src/input_processor/activator.rs
+++ b/presenter/src/input_processor/activator.rs
@@ -5,9 +5,7 @@
 //! The predicate is verified at every change of the states at the processor's context scope and
 //! might drop the subsequent processor at any time.
 
-use crate::input_processor::{Subscriber, Subscription, Subscriptions};
 use crate::{InputProcessor, InputState};
-use std::iter::FromIterator;
 use std::marker::PhantomData;
 
 pub struct Activator<R, PF, SP, CF, SC> {

--- a/presenter/src/input_processor/tap.rs
+++ b/presenter/src/input_processor/tap.rs
@@ -1,5 +1,5 @@
-use crate::input_processor::{Pan, Subscriber, Subscriptions, Transaction, WithMoveThreshold};
-use crate::{InputProcessor, InputState};
+use crate::input_processor::{Pan, Subscriber, Transaction, WithMoveThreshold};
+use crate::InputProcessor;
 use emergent_drawing::Point;
 use emergent_ui::WindowMessage;
 

--- a/presenter/src/lib.rs
+++ b/presenter/src/lib.rs
@@ -1,11 +1,14 @@
 #[macro_use]
 extern crate log;
 
-mod hit_test;
-pub use hit_test::*;
+mod context;
+pub use context::*;
 
 mod data;
 pub use data::*;
+
+mod hit_test;
+pub use hit_test::*;
 
 mod host;
 pub use host::*;
@@ -19,19 +22,19 @@ pub use input_state::*;
 mod interpolated;
 pub use interpolated::Interpolated;
 
-mod context;
-pub use context::*;
-
 mod processor_record;
 pub(crate) use processor_record::*;
 
 mod scoped_store;
 pub use scoped_store::*;
 
+mod support;
+pub use support::*;
+
 pub mod velocity;
 
 mod view;
 pub use view::*;
 
-mod support;
-pub use support::*;
+mod view_builder;
+pub use view_builder::*;

--- a/presenter/src/lib.rs
+++ b/presenter/src/lib.rs
@@ -28,6 +28,9 @@ pub(crate) use processor_record::*;
 mod scoped_store;
 pub use scoped_store::*;
 
+mod scoped_view;
+pub use scoped_view::*;
+
 mod support;
 pub use support::*;
 

--- a/presenter/src/processor_record.rs
+++ b/presenter/src/processor_record.rs
@@ -47,6 +47,10 @@ impl<Event> ProcessorRecord<Event> {
         &self.presentation_path
     }
 
+    pub(crate) fn presentation_path_mut(&mut self) -> &mut PresentationPath {
+        &mut self.presentation_path
+    }
+
     pub fn context_path(&self) -> &ContextPath {
         &self.context_path
     }

--- a/presenter/src/scoped_view.rs
+++ b/presenter/src/scoped_view.rs
@@ -1,0 +1,43 @@
+use crate::{View, ViewBuilder};
+use emergent_drawing::{
+    Bounds, DrawingBounds, DrawingFastBounds, MeasureText, Text, Transform, Transformed,
+};
+use emergent_presentation::PresentationScope;
+
+/// This type allows a parent view building function to apply certain mutations to the
+/// scoped view.
+pub struct ScopedView<Msg> {
+    view: View<Msg>,
+}
+
+impl<Msg> ScopedView<Msg> {
+    pub(crate) fn new(view: View<Msg>) -> Self {
+        Self { view }
+    }
+
+    fn map(self, f: impl Fn(View<Msg>) -> View<Msg>) -> Self {
+        Self { view: f(self.view) }
+    }
+
+    pub fn fast_bounds(&self, measure: &dyn MeasureText) -> DrawingBounds {
+        self.view.fast_bounds(measure)
+    }
+
+    pub fn transformed(self, transform: impl Into<Transform>) -> Self {
+        let transform = transform.into();
+        self.map(move |v| v.transformed(transform.clone()))
+    }
+
+    pub fn in_area(self) -> Self {
+        self.map(|v| v.in_area())
+    }
+
+    pub fn presentation_scoped(self, scope: impl Into<PresentationScope>) -> Self {
+        let scope = scope.into();
+        self.map(|v| v.presentation_scoped(scope.clone()))
+    }
+
+    pub(crate) fn into_view(self) -> View<Msg> {
+        self.view
+    }
+}

--- a/presenter/src/view.rs
+++ b/presenter/src/view.rs
@@ -76,11 +76,11 @@ impl<Msg> View<Msg> {
         }
     }
 
-    /// Attaches state to a View.
+    /// Sets a new state and makes it available to the current Context.
     /// Contrary to processors, this state block is never memoized.
     ///
-    /// Attaching state can be useful to provide additional information to input processors.
-    pub fn attach_state<S: 'static>(&mut self, state: S) {
+    /// Setting a state can be useful to provide additional information to input processors.
+    pub fn set_state<S: 'static>(&mut self, state: S) {
         self.states.push((ContextPath::new(), Box::new(state)));
     }
 

--- a/presenter/src/view/scroll.rs
+++ b/presenter/src/view/scroll.rs
@@ -80,7 +80,7 @@ pub fn view<Msg: 'static>(
     );
 
     let mut view = view.in_area();
-    view.attach_state(ConstrainedContentTransform(constrained_content_transform));
+    view.set_state(ConstrainedContentTransform(constrained_content_transform));
     view.attach_input_processor(&mut context, || {
         info!("creating new processor");
         let drift_duration = Duration::from_millis(500);

--- a/presenter/src/view/tab.rs
+++ b/presenter/src/view/tab.rs
@@ -1,8 +1,7 @@
 //! A view that presents data in multiple areas / tabs
 
-use crate::{Context, Direction, IndexAccessible, SimpleLayout, View, ViewReducer};
-use emergent_drawing::{DrawingFastBounds, ReplaceWith, Transformed, Vector};
-use std::{f32, mem};
+use crate::{Direction, ScopedView, SimpleLayout, View, ViewBuilder, ViewReducer};
+use emergent_drawing::{DrawingFastBounds, Transformed, Vector};
 
 struct State {
     focused_index: usize,
@@ -10,28 +9,21 @@ struct State {
 }
 
 pub fn view<Msg: 'static>(
-    mut context: Context,
-    build_content: impl FnOnce(&mut Context) -> Vec<View<Msg>>,
+    mut builder: ViewBuilder<Msg>,
+    build_content: impl FnOnce(&mut ViewBuilder<Msg>) -> Vec<ScopedView<Msg>>,
 ) -> View<Msg> {
-    // TODO: we should be able to define states separately from builders (returning a ContextWithState<State> like value).
-    let view = context.with_state(
-        || State {
-            focused_index: 0,
-            nested_transform: Vector::default(),
-        },
-        |mut c, s: &State| {
-            let views = build_content(&mut c);
-            assert!(!views.is_empty());
-            let focused = s.focused_index.min(views.len() - 1);
-            let bounds = Direction::Row.layout_bounds(views.iter().map(|v| v.fast_bounds(&c)));
-            let focused_bounds = bounds[focused].as_bounds();
-            let view = Direction::Row.reduce(c, views);
-            match focused_bounds {
-                Some(bounds) => view.transformed(bounds.point.to_vector()),
-                None => view,
-            }
-        },
-    );
-
-    view
+    let views = build_content(&mut builder);
+    assert!(!views.is_empty());
+    let state = builder.use_state(|| State {
+        focused_index: 0,
+        nested_transform: Vector::default(),
+    });
+    let focused = state.focused_index.min(views.len() - 1);
+    let bounds = Direction::Row.layout_bounds(views.iter().map(|v| v.fast_bounds(&builder)));
+    let focused_bounds = bounds[focused].as_bounds();
+    let view = Direction::Row.reduce_immediate(builder, views);
+    match focused_bounds {
+        Some(bounds) => view.transformed(bounds.point.to_vector()),
+        None => view,
+    }
 }

--- a/presenter/src/view_builder.rs
+++ b/presenter/src/view_builder.rs
@@ -1,0 +1,166 @@
+use crate::input_processor::Subscriber;
+use crate::{Context, ContextPath, ContextScope, InputProcessor, ProcessorRecord, Support, View};
+use emergent_drawing::{
+    Bounds, DrawingBounds, DrawingFastBounds, MeasureText, Rect, Text, Transform, Transformed,
+};
+use emergent_presentation::{Presentation, PresentationScope};
+use emergent_ui::WindowMessage;
+use std::any::Any;
+use std::iter;
+use std::ops::Deref;
+use std::rc::Rc;
+
+pub struct ViewBuilder<Msg> {
+    context: Context,
+
+    /// The recycled or newly generated processors that are active.
+    processors: Vec<ProcessorRecord<Msg>>,
+
+    /// The recycled or newly captured states of all the context scopes.
+    states: Vec<Box<dyn Any>>,
+}
+
+impl<Msg> ViewBuilder<Msg> {
+    // TODO: make this pub(crate) (used in from_test_environment())
+    pub fn new(context: Context) -> Self {
+        Self {
+            context,
+            processors: Vec::new(),
+            states: Vec::new(),
+        }
+    }
+
+    pub fn support(&self) -> &Rc<Support> {
+        self.context.support()
+    }
+
+    pub fn view_bounds(&self) -> Rect {
+        self.context.view_bounds()
+    }
+
+    /// Recycles a typed state from the current context or constructs it and binds it to the current view builder,
+    /// when it was not available before.
+    pub fn use_state<S: 'static>(&mut self, construct: impl FnOnce() -> S) -> &S {
+        let state = self.context.recycle_state().unwrap_or_else(construct);
+        // TODO: can the following two be combined?
+        self.set_state(state)
+    }
+
+    /// Sets a new state and makes it available to the current Context.
+    /// Contrary to `use_state`, this state block is never recycled.
+    ///
+    /// Setting a state can be useful to provide additional information to input processors.
+    pub fn set_state<S: 'static>(&mut self, state: S) -> &S {
+        let b = Box::new(state);
+        self.states.push(b);
+        self.states
+            .last()
+            .unwrap()
+            .deref()
+            .downcast_ref::<S>()
+            .unwrap()
+    }
+
+    /// Returns an already recycled state.
+    pub fn get_state<S: 'static>(&self) -> Option<&S> {
+        self.states
+            .iter()
+            .find_map(|s| s.deref().downcast_ref::<S>())
+    }
+
+    pub fn scoped(
+        &mut self,
+        scope: impl Into<ContextScope>,
+        builder: impl FnOnce(ViewBuilder<Msg>) -> View<Msg>,
+    ) -> ScopedView<Msg> {
+        let view = self.context.scoped(scope, |c| builder(Self::new(c)));
+        ScopedView::new(view)
+    }
+
+    /// Attaches a processor to a View.
+    ///
+    /// This function recycles a processor with the same type from the current context.
+    /// TODO: this function should not leak the type `ProcessorWithSubscription<R>`
+    /// TODO: is there any use here in returning the input processor similar to what `use_state()` does?
+    pub fn use_input_processor<R>(&mut self, construct: impl FnOnce() -> R)
+    where
+        R: InputProcessor<In = WindowMessage, Out = Msg> + Subscriber + 'static,
+    {
+        let r = self.context.recycle_state::<R>();
+        let r = r.unwrap_or_else(|| construct().into());
+
+        // need to store a function alongside the processor that converts it from an `Any` to its
+        // concrete type, so that it can be converted back to `Any` in the next rendering cycle.
+        let record = ProcessorRecord::new(r);
+        self.processors.push(record);
+    }
+
+    /// Convert the builder into a wrapped view. That is one that contains only one nested view.
+    pub fn wrapped(self, nested: ScopedView<Msg>) -> View<Msg> {
+        self.combined(iter::once(nested))
+    }
+
+    /// Converts the builder into a combined view containing a number of scoped views that are
+    /// rendered from back to front.
+    pub fn combined(self, nested: impl IntoIterator<Item = ScopedView<Msg>>) -> View<Msg> {
+        let container = self.present(Presentation::Empty);
+        View::new_combined(container, nested.into_iter().map(|sv| sv.into_view()))
+    }
+
+    /// Convert the builder into a (leaf) view that contains only a presentation.
+    pub fn present(self, presentation: Presentation) -> View<Msg> {
+        View::new(
+            presentation,
+            self.processors,
+            // TODO: may pre-generate with empty ContextPaths to avoid a reallocation here?
+            self.states
+                .into_iter()
+                .map(|s| (ContextPath::new(), s))
+                .collect(),
+        )
+    }
+}
+
+/// This type allows a parent view building function to apply certain mutations to the
+/// scoped view.
+pub struct ScopedView<Msg> {
+    view: View<Msg>,
+}
+
+impl<Msg> ScopedView<Msg> {
+    pub(crate) fn new(view: View<Msg>) -> Self {
+        Self { view }
+    }
+
+    fn map(self, f: impl Fn(View<Msg>) -> View<Msg>) -> Self {
+        Self { view: f(self.view) }
+    }
+
+    pub fn fast_bounds(&self, measure: &dyn MeasureText) -> DrawingBounds {
+        self.view.fast_bounds(measure)
+    }
+
+    pub fn transformed(self, transform: impl Into<Transform>) -> Self {
+        let transform = transform.into();
+        self.map(move |v| v.transformed(transform.clone()))
+    }
+
+    pub fn in_area(self) -> Self {
+        self.map(|v| v.in_area())
+    }
+
+    pub fn presentation_scoped(self, scope: impl Into<PresentationScope>) -> Self {
+        let scope = scope.into();
+        self.map(|v| v.presentation_scoped(scope.clone()))
+    }
+
+    pub(crate) fn into_view(self) -> View<Msg> {
+        self.view
+    }
+}
+
+impl<Msg> MeasureText for ViewBuilder<Msg> {
+    fn measure_text(&self, text: &Text) -> Bounds {
+        self.context.measure_text(text)
+    }
+}

--- a/presenter/src/view_builder.rs
+++ b/presenter/src/view_builder.rs
@@ -1,5 +1,7 @@
 use crate::input_processor::Subscriber;
-use crate::{Context, ContextPath, ContextScope, InputProcessor, ProcessorRecord, Support, View};
+use crate::{
+    Context, ContextPath, ContextScope, InputProcessor, ProcessorRecord, ScopedView, Support, View,
+};
 use emergent_drawing::{
     Bounds, DrawingBounds, DrawingFastBounds, MeasureText, Rect, Text, Transform, Transformed,
 };
@@ -118,44 +120,6 @@ impl<Msg> ViewBuilder<Msg> {
                 .map(|s| (ContextPath::new(), s))
                 .collect(),
         )
-    }
-}
-
-/// This type allows a parent view building function to apply certain mutations to the
-/// scoped view.
-pub struct ScopedView<Msg> {
-    view: View<Msg>,
-}
-
-impl<Msg> ScopedView<Msg> {
-    pub(crate) fn new(view: View<Msg>) -> Self {
-        Self { view }
-    }
-
-    fn map(self, f: impl Fn(View<Msg>) -> View<Msg>) -> Self {
-        Self { view: f(self.view) }
-    }
-
-    pub fn fast_bounds(&self, measure: &dyn MeasureText) -> DrawingBounds {
-        self.view.fast_bounds(measure)
-    }
-
-    pub fn transformed(self, transform: impl Into<Transform>) -> Self {
-        let transform = transform.into();
-        self.map(move |v| v.transformed(transform.clone()))
-    }
-
-    pub fn in_area(self) -> Self {
-        self.map(|v| v.in_area())
-    }
-
-    pub fn presentation_scoped(self, scope: impl Into<PresentationScope>) -> Self {
-        let scope = scope.into();
-        self.map(|v| v.presentation_scoped(scope.clone()))
-    }
-
-    pub(crate) fn into_view(self) -> View<Msg> {
-        self.view
     }
 }
 

--- a/src/lib/skia/test_environment.rs
+++ b/src/lib/skia/test_environment.rs
@@ -1,3 +1,12 @@
+pub mod view_builder {
+    use emergent_presenter::ViewBuilder;
+
+    pub fn from_test_environment<Msg>() -> ViewBuilder<Msg> {
+        let context = super::context::from_test_environment();
+        ViewBuilder::new(context)
+    }
+}
+
 pub mod context {
     use emergent_presenter::{Context, ScopedStore};
 


### PR DESCRIPTION
This PR separates views that are used as nested views in a builder context (`ScopedView<Msg>`) and views that are a final result of a builder function (`View<Msg`), it also uses `ViewBuilder<Msg>` to avoid the confusion to which states or recognizers need to be added to.