### PR TITLE
Trim views

### DIFF
--- a/drawing/src/drawing/transform.rs
+++ b/drawing/src/drawing/transform.rs
@@ -28,6 +28,7 @@ impl Transform {
         }
     }
 
+    // TODO: return Cow?
     pub fn to_matrix(&self) -> Matrix {
         match self {
             Transform::Identity => Matrix::new_identity(),

--- a/drawing/src/fast_bounds.rs
+++ b/drawing/src/fast_bounds.rs
@@ -55,6 +55,12 @@ impl Transformed for DrawingBounds {
     }
 }
 
+impl Transformed for Bounds {
+    fn transformed(self, transform: impl Into<Transform>) -> Self {
+        transform.into().to_matrix().map_bounds(self)
+    }
+}
+
 impl Contains<Point> for DrawingBounds {
     fn contains(&self, point: Point) -> bool {
         match self {
@@ -236,10 +242,8 @@ impl DrawingBounds {
 
     pub fn intersect(a: &DrawingBounds, b: &DrawingBounds) -> DrawingBounds {
         match (a, b) {
-            (DrawingBounds::Empty, _) => DrawingBounds::Empty,
-            (_, DrawingBounds::Empty) => DrawingBounds::Empty,
-            (DrawingBounds::Unbounded, b) => *b,
-            (a, DrawingBounds::Unbounded) => *a,
+            (DrawingBounds::Empty, _) | (_, DrawingBounds::Empty) => DrawingBounds::Empty,
+            (DrawingBounds::Unbounded, a) | (a, DrawingBounds::Unbounded) => *a,
             (DrawingBounds::Bounded(a), DrawingBounds::Bounded(b)) => {
                 match Bounds::intersect(&a, &b) {
                     Some(intersection) => DrawingBounds::Bounded(intersection),
@@ -258,10 +262,10 @@ impl DrawingBounds {
 impl Union for DrawingBounds {
     fn union(a: Self, b: Self) -> Self {
         match (a, b) {
-            (DrawingBounds::Empty, b) => b,
-            (a, DrawingBounds::Empty) => a,
-            (DrawingBounds::Unbounded, _) => DrawingBounds::Unbounded,
-            (_, DrawingBounds::Unbounded) => DrawingBounds::Unbounded,
+            (DrawingBounds::Empty, a) | (a, DrawingBounds::Empty) => a,
+            (DrawingBounds::Unbounded, _) | (_, DrawingBounds::Unbounded) => {
+                DrawingBounds::Unbounded
+            }
             (DrawingBounds::Bounded(a), DrawingBounds::Bounded(b)) => {
                 DrawingBounds::Bounded(Bounds::union(a, b))
             }

--- a/presentation/src/presentation.rs
+++ b/presentation/src/presentation.rs
@@ -1,7 +1,8 @@
 use crate::{Scope, ScopePath, Scoped};
 use emergent_drawing::{
-    BackToFront, Clip, Clipped, DrawTo, Drawing, DrawingBounds, DrawingFastBounds, DrawingTarget,
-    MeasureText, Outset, Paint, ReplaceWith, Transform, Transformed, Visualize, RGB,
+    BackToFront, Bounds, Clip, Clipped, DrawTo, Drawing, DrawingBounds, DrawingFastBounds,
+    DrawingTarget, FastBounds, MeasureText, Outset, Paint, ReplaceWith, Transform, Transformed,
+    Union, Visualize, RGB,
 };
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
@@ -58,30 +59,22 @@ impl Transformed for Presentation {
     }
 }
 
-/*
-impl<Msg> BackToFront<Presentation<Msg>> for Vec<Presentation<Msg>> {
-    fn back_to_front(self) -> Presentation<Msg> {
-        Presentation::BackToFront(self.into_iter().collect())
-    }
-}
-*/
-
 impl DrawingFastBounds for Presentation {
     fn fast_bounds(&self, measure: &dyn MeasureText) -> DrawingBounds {
-        use Presentation::*;
+        use Presentation as P;
         match self {
-            Empty => DrawingBounds::Empty,
+            P::Empty => DrawingBounds::Empty,
             // note: outset of area is not part of the drawing bounds.
-            Scoped(_, nested) | Area(_, nested) => nested.fast_bounds(measure),
-            InlineArea(_) => DrawingBounds::Empty,
-            Clipped(clip, nested) => nested.fast_bounds(measure).clipped(clip.clone()),
-            Transformed(transform, nested) => {
+            P::Scoped(_, nested) | P::Area(_, nested) => nested.fast_bounds(measure),
+            P::InlineArea(_) => DrawingBounds::Empty,
+            P::Clipped(clip, nested) => nested.fast_bounds(measure).clipped(clip.clone()),
+            P::Transformed(transform, nested) => {
                 nested.fast_bounds(measure).transformed(transform.clone())
             }
-            BackToFront(nested) => {
+            P::BackToFront(nested) => {
                 DrawingBounds::union_all(nested.iter().map(|n| n.fast_bounds(measure)))
             }
-            Drawing(nested) => nested.fast_bounds(measure),
+            P::Drawing(nested) => nested.fast_bounds(measure),
         }
     }
 }
@@ -160,6 +153,87 @@ impl Presentation {
             | Presentation::Transformed(_, _)
             | Presentation::Drawing(_) => Presentation::BackToFront(vec![p, presentation]),
         })
+    }
+
+    /// Returns a trimmed presentation and its trimmed bounds.
+    ///
+    /// Trimming a presentation removes elements that are _completely outside_ the given bounds.
+    ///
+    /// This also means that the returned trimmed size may be larger than the given bounds, e.g. when an
+    /// element is partially visible inside the `bounds`.
+    pub fn trimmed(self, bounds: Bounds, measure: &dyn MeasureText) -> (Self, DrawingBounds) {
+        use Presentation as P;
+        match self {
+            P::Empty => (self, DrawingBounds::Empty),
+            P::Scoped(scope, nested) => {
+                let (trimmed, trimmed_bounds) = nested.trimmed(bounds, measure);
+                (P::Scoped(scope, trimmed.into()), trimmed_bounds)
+            }
+            P::Area(outset, nested) => {
+                // TODO: handle outset clipping properly.
+                let (trimmed, trimmed_bounds) = nested.trimmed(bounds, measure);
+                (P::Area(outset, trimmed.into()), trimmed_bounds)
+            }
+            P::InlineArea(clip) => {
+                if let Some(intersection) = Bounds::intersect(&clip.fast_bounds(), &bounds) {
+                    // we keep the original clip, but return the intersection with bounds.
+                    (P::InlineArea(clip), intersection.into())
+                } else {
+                    (P::Empty, DrawingBounds::Empty)
+                }
+            }
+            P::Clipped(clip, nested) => {
+                let clip_bounds = clip.fast_bounds();
+                if let Some(intersection) = Bounds::intersect(&bounds, &clip_bounds) {
+                    let (trimmed, trimmed_bounds) = nested.trimmed(intersection, measure);
+                    (
+                        P::Clipped(clip, trimmed.into()),
+                        // trimmed nested bounds may be larger than clip, but they are are expected
+                        // to be visually trimmed by the renderer, so we return the intersection
+                        // of the clip and the trimmed bounds as the trimmed bounds of the clip.
+                        DrawingBounds::intersect(&bounds.into(), &trimmed_bounds),
+                    )
+                } else {
+                    (P::Empty, DrawingBounds::Empty)
+                }
+            }
+            P::Transformed(transform, nested) => {
+                if let Some(inv_trans) = transform.invert() {
+                    let bounds = bounds.transformed(inv_trans);
+                    let (trimmed, trimmed_bounds) = nested.trimmed(bounds, measure);
+                    (
+                        P::Transformed(transform.clone(), trimmed.into()),
+                        trimmed_bounds.transformed(transform),
+                    )
+                } else {
+                    // TODO: log / display an error here.
+                    (P::Empty, DrawingBounds::Empty)
+                }
+            }
+            P::BackToFront(mut presentations) => {
+                // TODO: remove empty ones?
+                let mut trimmed_bounds_union = DrawingBounds::Empty;
+                for i in 0..presentations.len() {
+                    presentations[i].replace_with(|p| {
+                        let (trimmed, trimmed_bounds) = p.trimmed(bounds, measure);
+                        trimmed_bounds_union =
+                            DrawingBounds::union(trimmed_bounds_union, trimmed_bounds);
+                        trimmed
+                    });
+                }
+                (P::BackToFront(presentations), trimmed_bounds_union)
+            }
+            P::Drawing(ref drawing) => {
+                // TODO: may trim drawing's content?
+                let drawing_bounds = drawing.fast_bounds(measure);
+                if DrawingBounds::intersect(&bounds.into(), &drawing_bounds) != DrawingBounds::Empty
+                {
+                    (self, drawing_bounds)
+                } else {
+                    (P::Empty, DrawingBounds::Empty)
+                }
+            }
+        }
     }
 }
 

--- a/presentation/src/scope.rs
+++ b/presentation/src/scope.rs
@@ -7,11 +7,12 @@ use std::marker::PhantomData;
 ///
 /// The type argument `T` is used to discriminate different types of scope paths.
 ///
-/// # Notes
+/// # Performance
 ///
 /// - Even though `VecDeque` would probably be a better type, we have uses in which we prefer to
 ///   access parts of paths through slices.
-
+/// - Path lengths should not exceed a few elements, so inserting at the beginning might not
+///   be that expensive.
 pub type ScopePath<T> = Vec<Scope<T>>;
 
 /// A trait that can be implemented by types that can be extended with / put into a scope.

--- a/presenter/src/host.rs
+++ b/presenter/src/host.rs
@@ -52,8 +52,8 @@ impl<Msg> Host<Msg> {
         let builder = ViewBuilder::new(context);
 
         let view = {
-            let (width, height) = boundary.dimensions;
             let view = present(builder);
+            let (width, height) = boundary.dimensions;
             view.trimmed(
                 Bounds::new(Point::ZERO, Extent::from((width as isize, height as isize))),
                 self.support.deref(),

--- a/presenter/src/host.rs
+++ b/presenter/src/host.rs
@@ -3,6 +3,7 @@ use crate::{
     AreaHitTest, Context, InputProcessor, InputState, ProcessorRecord, ScopedStore, Support, View,
     ViewBuilder,
 };
+use emergent_drawing::{Bounds, Extent, Point};
 use emergent_presentation::Presentation;
 use emergent_ui::{FrameLayout, WindowMessage};
 use std::any::TypeId;
@@ -49,7 +50,16 @@ impl<Msg> Host<Msg> {
 
         let context = Context::new(self.support.clone(), boundary, store);
         let builder = ViewBuilder::new(context);
-        let (presentation, processors, states) = present(builder).destructure();
+
+        let view = {
+            let (width, height) = boundary.dimensions;
+            let view = present(builder);
+            view.trimmed(
+                Bounds::new(Point::ZERO, Extent::from((width as isize, height as isize))),
+                self.support.deref(),
+            )
+        };
+        let (presentation, processors, states) = view.destructure();
 
         self.presentation = presentation;
         self.processors = processors;

--- a/presenter/src/view.rs
+++ b/presenter/src/view.rs
@@ -1,6 +1,7 @@
 use crate::{ContextPath, ContextScope, ProcessorRecord, ScopedState, ViewBuilder};
 use emergent_drawing::{
-    DrawingBounds, DrawingFastBounds, MeasureText, ReplaceWith, Transform, Transformed,
+    Bounds, DrawingBounds, DrawingFastBounds, MeasureText, Rect, ReplaceWith, Transform,
+    Transformed,
 };
 use emergent_presentation::{Presentation, PresentationScope, Scoped};
 use std::any::Any;
@@ -122,6 +123,20 @@ impl<Msg> View<Msg> {
     pub fn with_state(mut self, state: impl Any + 'static) -> Self {
         self.states.push((ContextPath::new(), Box::new(state)));
         self
+    }
+
+    /// Returns this view trimmed to a boundary.
+    ///
+    /// This removes
+    /// - parts of the presentation that are completely outside the boundary rectangle.
+    /// - processors of which their presentation scope does not exist anymore and don't
+    ///   have any active subscriptions.
+    pub fn trimmed(self, bounds: Bounds, measure: &dyn MeasureText) -> Self {
+        let (presentation, _) = self.presentation.trimmed(bounds, measure);
+        Self {
+            presentation,
+            ..self
+        }
     }
 }
 

--- a/presenter/src/view.rs
+++ b/presenter/src/view.rs
@@ -127,10 +127,14 @@ impl<Msg> View<Msg> {
 
     /// Returns this view trimmed to a boundary.
     ///
-    /// This removes
-    /// - parts of the presentation that are completely outside the boundary rectangle.
-    /// - processors of which their presentation scope does not exist anymore and don't
-    ///   have any active subscriptions.
+    /// This removes parts of the presentation that are completely outside the boundary rectangle.
+    ///
+    /// # Note
+    ///
+    /// Processors of which their presentation scope does not exist anymore and don't
+    /// have any active subscriptions could be removed, but are not so far, because keeping
+    /// them around probably has no significant performance drawbacks. This might change if we
+    /// do the trimming more than once for a single presentation run.
     pub fn trimmed(self, bounds: Bounds, measure: &dyn MeasureText) -> Self {
         let (presentation, _) = self.presentation.trimmed(bounds, measure);
         Self {

--- a/presenter/src/view_builder.rs
+++ b/presenter/src/view_builder.rs
@@ -2,10 +2,8 @@ use crate::input_processor::Subscriber;
 use crate::{
     Context, ContextPath, ContextScope, InputProcessor, ProcessorRecord, ScopedView, Support, View,
 };
-use emergent_drawing::{
-    Bounds, DrawingBounds, DrawingFastBounds, MeasureText, Rect, Text, Transform, Transformed,
-};
-use emergent_presentation::{Presentation, PresentationScope};
+use emergent_drawing::{Bounds, MeasureText, Rect, Text, Transform, Transformed};
+use emergent_presentation::Presentation;
 use emergent_ui::WindowMessage;
 use std::any::Any;
 use std::iter;


### PR DESCRIPTION
This PR clips the generated views' presentations to the bounds of the current frame and so improves the generation of presentations significantly.

Clipping is done only once for the whole frame for now. Time will tell if this is sufficient when combined with other caching mechanisms.